### PR TITLE
Adjusted Publications css

### DIFF
--- a/src/components/PublicationsHero.css
+++ b/src/components/PublicationsHero.css
@@ -1,13 +1,13 @@
 .publications-hero-container img {
     object-fit: cover;
     width: 100%;
-    height: 90%;
+    height: 100%;
     position: fixed;
     z-index: -1;
 }
 
 .publications-hero-container {
-    height: 90vh;
+    height: 100vh;
     width: 100%;
     display: flex;
     margin-bottom:-80px;

--- a/src/components/PublicationsMain.css
+++ b/src/components/PublicationsMain.css
@@ -7,7 +7,6 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    align-items: center;
     object-fit: contain;
 }
 


### PR DESCRIPTION
Adjusted the hero container height and made the main container text fill the screen when the screen is minimized. This required adjusting PublicationsHero.css and PublicationsMain.css, and changes were tested locally.